### PR TITLE
fix implementation of binom_pmf to handle large k/n

### DIFF
--- a/binomial_cis/binomial_helper.py
+++ b/binomial_cis/binomial_helper.py
@@ -44,8 +44,8 @@ def binom_pmf(k, n, p):
     else:
         # following code from https://stackoverflow.com/a/45869209
         log_binom_coeff = 0
-        for i in range(1, int(k) + 1): # should loop from i = 1, ..., k
-            log_binom_coeff += np.log(n - i + 1 ) - np.log(i)
+        for i in range(1, int(min(k, n - k)) + 1): # should loop from i = 1, ..., k
+            log_binom_coeff += np.log(n - i + 1) - np.log(i)
         log_pmf = log_binom_coeff + k * np.log(p) + (n-k) * np.log1p(-p)
         pmf = np.exp(log_pmf)
         # safeguard against floating point errors

--- a/binomial_cis/binomial_helper.py
+++ b/binomial_cis/binomial_helper.py
@@ -31,10 +31,25 @@ def binom_pmf(k, n, p):
     Returns
     pmf: binomial pmf evaluated at k, n, p
     """
-    pmf = binom_coeff(n, k) * p**k * (1-p)**(n-k)
-    
-    # safeguard against floating point errors
-    pmf = min(1, max(0, pmf)) # unable to use np.clip()
+    if p == 1:
+        if k == n:
+            pmf = 1
+        else:
+            pmf = 0
+    elif p == 0:
+        if k == 0:
+            pmf = 1
+        else:
+            pmf = 0
+    else:
+        # following code from https://stackoverflow.com/a/45869209
+        log_binom_coeff = 0
+        for i in range(1, int(k) + 1): # should loop from i = 1, ..., k
+            log_binom_coeff += np.log(n - i + 1 ) - np.log(i)
+        log_pmf = log_binom_coeff + k * np.log(p) + (n-k) * np.log1p(-p)
+        pmf = np.exp(log_pmf)
+        # safeguard against floating point errors
+        pmf = min(1, max(0, pmf)) # unable to use np.clip()
     return pmf
 
 

--- a/binomial_cis/binomial_helper.py
+++ b/binomial_cis/binomial_helper.py
@@ -42,9 +42,10 @@ def binom_pmf(k, n, p):
         else:
             pmf = 0
     else:
-        # following code from https://stackoverflow.com/a/45869209
+        # Use the multiplicative formula for computational efficiency:
+        # https://en.wikipedia.org/wiki/Binomial_coefficient#Multiplicative_formula
         log_binom_coeff = 0
-        for i in range(1, int(min(k, n - k)) + 1): # should loop from i = 1, ..., k
+        for i in range(1, int(min(k, n - k)) + 1):
             log_binom_coeff += np.log(n - i + 1) - np.log(i)
         log_pmf = log_binom_coeff + k * np.log(p) + (n-k) * np.log1p(-p)
         pmf = np.exp(log_pmf)


### PR DESCRIPTION
Corrects the `binom_pmf` implementation to follow the log-space implementation of `binom_cdf` to address over/underflow for large k/n. 

EDIT: As requested by @Joe-Vincent, screenshot of cell output for `binom_pmf` within the `binomial_helper_validation.ipynb` notebook. 
![Screenshot from 2025-04-12 20-50-04](https://github.com/user-attachments/assets/be6c64b2-0872-4c05-8a76-3609430a16c1)
